### PR TITLE
Smw 2.3

### DIFF
--- a/classes/RDFIO_ARC2StoreWrapper.php
+++ b/classes/RDFIO_ARC2StoreWrapper.php
@@ -85,7 +85,7 @@ class RDFIOARC2StoreWrapper {
     public function getWikiTitleByEquivalentURI( $uri, $isProperty = false ) {
         $uriEncoded = str_replace(' ', '%20', $uri);
         $wikiTitleResolverUri = $this->getURIForEquivURI( $uriEncoded, $isProperty );
-        $wikiTitleResolverUriDecoded = Escaper::decodeURI( $wikiTitleResolverUri );
+        $wikiTitleResolverUriDecoded = SMWExporter::getInstance()->decodeURI( $wikiTitleResolverUri );
 
         $uriParts = explode('/', rtrim( $wikiTitleResolverUriDecoded , '/') ); 
         $wikiTitle = str_replace('_', ' ', array_pop( $uriParts ));

--- a/classes/RDFIO_ARC2StoreWrapper.php
+++ b/classes/RDFIO_ARC2StoreWrapper.php
@@ -85,7 +85,7 @@ class RDFIOARC2StoreWrapper {
     public function getWikiTitleByEquivalentURI( $uri, $isProperty = false ) {
         $uriEncoded = str_replace(' ', '%20', $uri);
         $wikiTitleResolverUri = $this->getURIForEquivURI( $uriEncoded, $isProperty );
-        $wikiTitleResolverUriDecoded = SMWExporter::decodeURI( $wikiTitleResolverUri );
+        $wikiTitleResolverUriDecoded = Escaper::decodeURI( $wikiTitleResolverUri );
 
         $uriParts = explode('/', rtrim( $wikiTitleResolverUriDecoded , '/') ); 
         $wikiTitle = str_replace('_', ' ', array_pop( $uriParts ));

--- a/specials/SpecialSPARQLEndpoint_body.php
+++ b/specials/SpecialSPARQLEndpoint_body.php
@@ -24,7 +24,7 @@ class SPARQLEndpoint extends SpecialPage {
     /**
      * The main function
      */
-    function execute() {
+    function execute( $par ) {
         global $wgOut;
 
         $this->setHeaders();

--- a/stores/SMW_ARC2Store.php
+++ b/stores/SMW_ARC2Store.php
@@ -28,7 +28,7 @@ class SMWARC2Store extends SMWSQLStore3 {
      * @param $subject
      */
     public function deleteSubject( Title $subject ) {
-        $subject_uri = SMWExporter::expandURI( $this->getURI( $subject ) );
+        $subject_uri = SMWExporter::getInstance()->expandURI( $this->getURI( $subject ) );
         $this->removeDataForURI( $subject_uri );
 
         return parent::deleteSubject( $subject ); // Also update via SQLStore3
@@ -40,8 +40,8 @@ class SMWARC2Store extends SMWSQLStore3 {
      */
     public function updateData( SMWSemanticData $data ) {
     	// TODO: Should doDataUpdate() be used instead? (See SMWStore class)
-        $exportData = SMWExporter::makeExportData( $data );
-        $subjectUri = SMWExporter::expandURI( $exportData->getSubject()->getUri() );
+        $exportData = SMWExporter::getInstance()->makeExportData( $data );
+        $subjectUri = SMWExporter::getInstance()->expandURI( $exportData->getSubject()->getUri() );
 
         $this->removeDataForURI( $subjectUri );
         $tripleList = $exportData->getTripleList();
@@ -60,17 +60,17 @@ class SMWARC2Store extends SMWSQLStore3 {
             	// TODO: Add escaping for results of getLexicalForm()?
                 $objectStr = "\"" . $object->getLexicalForm() . "\"" . ( ( $object->getDatatype() == "" ) ? "" : "^^<" . $object->getDatatype() . ">" );
             } elseif ( $object instanceof SMWExpResource ) {
-                $objectStr = "<" . SMWExporter::expandURI( $object->getUri() ) . ">";
+                $objectStr = "<" . SMWExporter::getInstance()->expandURI( $object->getUri() ) . ">";
             } else {
                 $objectStr = "\"\"";
             }
 
             if ( $subject instanceof SMWExpResource ) {
-                $subjectStr = "<" . SMWExporter::expandURI( $subject->getUri() ) . ">";
+                $subjectStr = "<" . SMWExporter::getInstance()->expandURI( $subject->getUri() ) . ">";
             }
 
             if ( $predicate instanceof SMWExpResource ) {
-                $predicateStr = "<" . SMWExporter::expandURI( $predicate->getUri() ) . ">";
+                $predicateStr = "<" . SMWExporter::getInstance()->expandURI( $predicate->getUri() ) . ">";
             }
 
             $sparqlUpdateText .= $subjectStr . " " . $predicateStr . " " . $objectStr . " .\n";
@@ -95,7 +95,7 @@ class SMWARC2Store extends SMWSQLStore3 {
         $result = parent::changeTitle( $oldTitle, $newTitle, $pageId, $redirectId );
 
         // Delete old stuff
-        $oldUri = SMWExporter::expandURI( $this->getURI( $oldTitle ) );
+        $oldUri = SMWExporter::getInstance()->expandURI( $this->getURI( $oldTitle ) );
         $this->removeDataForURI( $oldUri );
 
         $newpage = SMWDataValueFactory::newTypeIDValue( '_wpg' );
@@ -172,7 +172,7 @@ class SMWARC2Store extends SMWSQLStore3 {
         $uri = "";
         if ( $title instanceof Title ) {
             $wikiPageDI = SMWDIWikiPage::newFromTitle( $title );
-            $exp = SMWExporter::makeExportDataForSubject( $wikiPageDI ); 
+            $exp = SMWExporter::getInstance()->makeExportDataForSubject( $wikiPageDI ); 
             $uri = $exp->getSubject()->getUri();
         } else {
             // There could be other types as well that we do NOT handle here


### PR DESCRIPTION
Fixed SMWExporter static methods as requested in issue #11 - this should make it work for SMW 2.0+ (won't be compatible with earlier versions).  This'll sort the immediate usability issue & I'll review the new feature release when I can.